### PR TITLE
fix a bug in parsing headers

### DIFF
--- a/src/NETStandard.HttpListener/HttpListenerHeaders.cs
+++ b/src/NETStandard.HttpListener/HttpListenerHeaders.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http
         {
             foreach (var headerLine in lines)
             {
-                var parts = headerLine.Split(':');
+                var parts = headerLine.Split(new char[] { ':' }, 2);
                 var key = parts[0];
                 var value = parts[1].Trim();
                 Add(key, value);


### PR DESCRIPTION
Use Split's overload in case there are colons in the value part.